### PR TITLE
Added channel control for each chip

### DIFF
--- a/lib/VGMEngine/VGMEngine.h
+++ b/lib/VGMEngine/VGMEngine.h
@@ -61,6 +61,13 @@ public:
     uint16_t getLoops();
     uint16_t maxLoops = 3;
     bool loopOneOffs = false;
+    //There are only 6 channels, but for chip writes we use (0x00, 0x01, 0x02, 0x04, 0x05 and 0x06)
+    //The extra array positions are there just to avoid crashes in case the VGM file tries to write to an invalid channel
+    bool ym2612CHControl[8] = {true, true, true, true, true, true, true, true};
+    //There are 4 channels on PSG (3 tone and 1 noise)
+    bool sn76489CHControl[4] = {true, true, true, true};
+    //Keeps track of the currently latched channel so we can ignore writes if disabled
+    uint8_t sn76489Latched = 0;
     VGMEngineState state = IDLE;
     bool resetISR = false;
     bool isBusy = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,7 +2,7 @@
 //CHIP SELECT FEATURES MANUALLY ADJUSTED IN SDFAT LIB (in SdSpiDriver.h). MUST USE LIB INCLUDED WITH REPO!!!
 
 #define BOOTLOADER_VERSION "1.0"
-#define FIRMWARE_VERSION "1.23"
+#define FIRMWARE_VERSION "1.24"
 
 #include <Arduino.h>
 #include <SPI.h>
@@ -156,12 +156,76 @@ TOGGLE(VGMEngine.loopOneOffs, setLoopOneOff, "Loop One-offs: ", doNothing, noEve
     ,VALUE("NO",false,doNothing,noEvent)
 );
 
+TOGGLE(VGMEngine.ym2612CHControl[0x00], setYM2612CH1, "FM CH1: ", doNothing, noEvent, noStyle
+    ,VALUE("YES",true,doNothing,noEvent)
+    ,VALUE("NO",false,doNothing,noEvent)
+);
+
+TOGGLE(VGMEngine.ym2612CHControl[0x01], setYM2612CH2, "FM CH2: ", doNothing, noEvent, noStyle
+    ,VALUE("YES",true,doNothing,noEvent)
+    ,VALUE("NO",false,doNothing,noEvent)
+);
+
+TOGGLE(VGMEngine.ym2612CHControl[0x02], setYM2612CH3, "FM CH3: ", doNothing, noEvent, noStyle
+    ,VALUE("YES",true,doNothing,noEvent)
+    ,VALUE("NO",false,doNothing,noEvent)
+);
+
+TOGGLE(VGMEngine.ym2612CHControl[0x04], setYM2612CH4, "FM CH4: ", doNothing, noEvent, noStyle
+    ,VALUE("YES",true,doNothing,noEvent)
+    ,VALUE("NO",false,doNothing,noEvent)
+);
+
+TOGGLE(VGMEngine.ym2612CHControl[0x05], setYM2612CH5, "FM CH5: ", doNothing, noEvent, noStyle
+    ,VALUE("YES",true,doNothing,noEvent)
+    ,VALUE("NO",false,doNothing,noEvent)
+);
+
+TOGGLE(VGMEngine.ym2612CHControl[0x06], setYM2612CH6, "FM CH6: ", doNothing, noEvent, noStyle
+    ,VALUE("YES",true,doNothing,noEvent)
+    ,VALUE("NO",false,doNothing,noEvent)
+);
+
+TOGGLE(VGMEngine.sn76489CHControl[0x00], setSN76489CH1, "PSG CH1: ", doNothing, noEvent, noStyle
+    ,VALUE("YES",true,doNothing,noEvent)
+    ,VALUE("NO",false,doNothing,noEvent)
+);
+
+TOGGLE(VGMEngine.sn76489CHControl[0x01], setSN76489CH2, "PSG CH2: ", doNothing, noEvent, noStyle
+    ,VALUE("YES",true,doNothing,noEvent)
+    ,VALUE("NO",false,doNothing,noEvent)
+);
+
+TOGGLE(VGMEngine.sn76489CHControl[0x02], setSN76489CH3, "PSG CH3: ", doNothing, noEvent, noStyle
+    ,VALUE("YES",true,doNothing,noEvent)
+    ,VALUE("NO",false,doNothing,noEvent)
+);
+
+TOGGLE(VGMEngine.sn76489CHControl[0x03], setSN76489CH4, "PSG CH4: ", doNothing, noEvent, noStyle
+    ,VALUE("YES",true,doNothing,noEvent)
+    ,VALUE("NO",false,doNothing,noEvent)
+);
+
+MENU(channelControl,"Channel Control",doNothing,noEvent,wrapStyle
+  ,SUBMENU(setYM2612CH1)
+  ,SUBMENU(setYM2612CH2)
+  ,SUBMENU(setYM2612CH3)
+  ,SUBMENU(setYM2612CH4)
+  ,SUBMENU(setYM2612CH5)
+  ,SUBMENU(setYM2612CH6)
+  ,SUBMENU(setSN76489CH1)
+  ,SUBMENU(setSN76489CH2)
+  ,SUBMENU(setSN76489CH3)
+  ,SUBMENU(setSN76489CH4)
+);
+
 #define MAX_DEPTH 2
 MENU(mainMenu,"Main menu",doNothing,noEvent,wrapStyle
   ,SUBMENU(filePickMenu)
   ,SUBMENU(modeMenu)
   ,FIELD(VGMEngine.maxLoops,"Loops: ","",1,255,1,10,doNothing,noEvent,noStyle)
   ,SUBMENU(setLoopOneOff)
+  ,SUBMENU(channelControl)
   //,EXIT("<Back")
 );
 


### PR DESCRIPTION
Implementation of a channel control mechanism.

It modifies certain chip writes to silence channels on both YM2612  (key on/off) and SN76489 (volume attenuation).

For SN76489 it needs to keep track of the current latched channel to also skip data writes if that channel is disabled. This is because you can technically latch a channel for full volume attenuation then use a data write to change volume levels. The data write is never ignored once a channel is latched.

As for the YM2612, this approach for disabling key on/off writes was chosen to minimize disruption of instrument setup on each channel, meaning the chip won't produce weird sounds when enabled in the middle of a song that's already playing. In theory all channels are being parameterized properly (even if disabled) but won't make sound until enabled in the UI. 