### PR TITLE
Reset sample counter upon first VGM wait period

### DIFF
--- a/lib/VGMEngine/VGMEngine.cpp
+++ b/lib/VGMEngine/VGMEngine.cpp
@@ -62,6 +62,7 @@ bool VGMEngineClass::begin(File *f)
     storePCM();
     pcmBufferPosition = 0;
     waitSamples = 0;
+    firstWait = true;
     loopCount = 0;
     badCommandCount = 0;
     dacSampleCountDown = 0;
@@ -338,7 +339,16 @@ VGMEngineState VGMEngineClass::play()
         while(waitSamples <= 0)
         {
             isBusy = true;
-            waitSamples += parseVGM();
+            uint16_t smpls = parseVGM();
+            if (firstWait && smpls)
+            {
+                waitSamples = smpls;
+                firstWait = false;
+            }
+            else
+            {
+                waitSamples += smpls;
+            }
         }
 
         isBusy = false;

--- a/lib/VGMEngine/VGMEngine.h
+++ b/lib/VGMEngine/VGMEngine.h
@@ -79,6 +79,7 @@ private:
     File* file;
     static const uint32_t VGM_BUF_SIZE = 16384;
     volatile int32_t waitSamples = 0;
+    bool firstWait = true;
     volatile bool ready = false;
     bool bufLock = false;
     uint16_t badCommandCount = 0;


### PR DESCRIPTION
Fixes playback speed anomalies on VGMs that have a bunch of trash on the first sample.

Unable to test myself but Chickentail seems to be satisfied :) so it's probably good